### PR TITLE
bugfix for segmentation fault which is sometimes triggered after a wa…

### DIFF
--- a/source/FileWatcherLinux.cpp
+++ b/source/FileWatcherLinux.cpp
@@ -151,8 +151,10 @@ namespace FW
 			{
 				struct inotify_event *pevent = (struct inotify_event *)&buff[i];
 
-				WatchStruct* watch = mWatches[pevent->wd];
-				handleAction(watch, pevent->name, pevent->mask);
+				auto itWatch = mWatches.find(pevent->wd);
+				if (itWatch != mWatches.end()) {
+					handleAction(itWatch->second, pevent->name, pevent->mask);
+				}
 				i += sizeof(struct inotify_event) + pevent->len;
 			}
 		}


### PR DESCRIPTION
sometimes after removeWatch() was called, handleAction(...) triggered a segmentation fault. This is because in removeWatch the Watch* was deleted and removed from mWatches. In the update function mWatches[pevent->wd] is called which creates a new map entry with a random pointer.